### PR TITLE
Remove duplicate predicates

### DIFF
--- a/utils/nessus_translate.sh
+++ b/utils/nessus_translate.sh
@@ -20,6 +20,11 @@ export MALLOC_CHECK_=0
 CLASSPATH=$CLASSPATH:$MULVALROOT/lib/dom4j-1.6.1.jar:$MULVALROOT/lib/jaxen-1.1.1.jar:$MULVALROOT/lib/mysql-connector-java-5.1.8-bin.jar:$MULVALROOT/bin/adapter
 ADAPTERSRCPATH=$MULVALROOT/src/adapter
 
+if [ -z "$XSBHOME" ]; then
+    echo '$XSBHOME environment variable not set.'
+    exit -1
+fi
+
 if [ ! -r config.txt ]; then
     echo "config.txt does not exist. Please refer to the README and create config.txt first."
     exit 1
@@ -51,16 +56,18 @@ xsb 2>$xsb_logfile 1>&2 <<EOF
 [results].
 ['$MULVALROOT/lib/libmulval'].
 ['$ADAPTERSRCPATH/nessus_translator'].
+['$XSBHOME/syslib/machine'].
 tell('nessus.P').
-findall(vulProperty(A,B,C),vulProperty(A,B,C),L),list_apply(L,write_clause_to_stdout).
+
+findall(vulProperty(A,B,C), vulProperty(A,B,C), L), parsort(L, [asc(1)], 1, P), list_apply(P, write_clause_to_stdout).
 
 %findall(remote_client_vul_exists(A,B),remote_client_vul_exists(A,B),L),list_apply(L,write_clause_to_stdout).
 
-findall(vulExists(A,B,C),vulExists(A,B,C),L),list_apply(L,write_clause_to_stdout).
+findall(vulExists(A,B,C), vulExists(A,B,C), L), list_apply(L, write_clause_to_stdout).
 
-findall(cvss(CVE, AC),cvss(CVE, AC),L),list_apply(L,write_clause_to_stdout).
+findall(cvss(CVE, AC), cvss(CVE, AC), L), parsort(L, [asc(1)], 1, P), list_apply(P, write_clause_to_stdout).
 
-findall(networkServiceInfo(Host, Program, Protocol, Port, someUser), networkServiceInfo(Host, Program, Protocol, Port, someUser), L), list_apply(L,write_clause_to_stdout).
+findall(networkServiceInfo(Host, Program, Protocol, Port, someUser), networkServiceInfo(Host, Program, Protocol, Port, someUser), L), parsort(L, [asc(1)], 1, P), list_apply(P,write_clause_to_stdout).
 
 %findall(hacl(Host, Host1, Protocol, Port), hacl(Host, Host1, Protocol, Port), L), list_apply(L,write_clause_to_stdout).
 


### PR DESCRIPTION
`nessus_translate.sh` script generated duplicate predicates for each instance of vulnerability
that was present in the input nessus file. This commit modifies some XSB code to remove any duplicate
predicates from the output nessus.P file. This results in a short and clean output.
