### PR TITLE
Writing hacl rules to output nessus file

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ as desired to keep the local MySQL database in sync with NVD.
     * oval.P is raw input to MulVAL.
     * summ_oval.P is a summarized input after performing grouping as outlined in [3]. This input file is to be used with the `-ma` option. (grps_oval.P contains mapping from vuln groups to raw vuln's)
 
-  * For NESSUS: `nessus_translate.sh XML_REPORT_FROM_NESSUS`
+  * For NESSUS: `nessus_translate.sh XML_NESSUS_REPORT [FIREWALL_RULES]`
     * The first parameter is the XML file of NESSUS scanning result.
+    * Optional second parameter is a file containing firewall rules in datalog format. For example `hacl('10.1.2.3', '172.28.2.5', udp, _).` One hacl is defined per line. All rules from this file will be written to `nessus.P` file. If this parameter is missing, then a default rule `hacl(_, _, _, _).` will be written.
     * The output will be in nessus.P, summ_nessus.P, and grps_nessus.P
     * nessus.P is the raw input to MulVAL
     * summ_nessus.P is a summarized input after performing grouping as outlined in [3]. This input file is to be used with the `-ma` option. (grps_nessus.P contains mapping from vuln groups to raw vuln's)

--- a/utils/nessus_translate.sh
+++ b/utils/nessus_translate.sh
@@ -36,7 +36,7 @@ if [ -r connectionSucc.txt ]; then
     echo 'connection tested successfully'
 else
 # echo 'connection cannot be established'
- exit 1
+    exit 1
 fi
 
 java -cp $CLASSPATH NessusXMLParser $1
@@ -44,8 +44,8 @@ java -cp $CLASSPATH NessusXMLParser $1
 if grep -qF "CVE" vulInfo.txt; then
     echo 'vulnerability(ies) detected'
 else
- echo 'no vulnerability detected'
- exit 1
+    echo 'no vulnerability detected'
+    exit 1
 fi
 
 
@@ -81,7 +81,14 @@ if [ ! -e nessus.P ]; then
 fi
 
 cat accountinfo.P >> nessus.P
-echo "hacl(_,_,_,_).">>nessus.P
+
+if [ -z "$2" ]; then
+	echo "Firewall rules missing."
+	echo "hacl(_,_,_,_).">>nessus.P
+else
+	echo "Firewall rules provided."
+	cat $2 >> nessus.P
+fi
 #cat $ADAPTERSRCPATH/client_software.P>> nessus.P
 echo "Output can be found in nessus.P."
 
@@ -90,5 +97,11 @@ echo "Output can be found in nessus.P."
 # Perform summarization
 nessus_vul_summary.sh nessus.P
 cat accountinfo.P >>summ_nessus.P
-echo "hacl(_,_,_,_).">>summ_nessus.P
+
+if [ -z "$2" ]; then
+    echo "hacl(_,_,_,_).">>summ_nessus.P
+else
+    cat $2 >> summ_nessus.P
+fi
 #cat $ADAPTERSRCPATH/client_software.P >> summ_nessus.P
+


### PR DESCRIPTION
`nessus_translate.sh` script accepts optional parameter containing path of a file
that has hacl rules. These rules are copied to the resulting files nessus.P and
summ_nessus.P. If the user does not provide the second parameter, default rule
`hacl(_, _, _, _)` will be copied.

firewallIntegration
